### PR TITLE
Fix for the #68 

### DIFF
--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/DownloadExercisesTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/DownloadExercisesTest.java
@@ -62,10 +62,12 @@ public class DownloadExercisesTest {
     private TmcApi tmcApi;
     private TmcCore core;
 
-    @Rule public WireMockRule wireMockServer = new WireMockRule();
+    @Rule public WireMockRule wireMockServer = new WireMockRule(0);
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setup() throws IOException {
+        serverAddress += wireMockServer.port();
         settings = new CoreTestSettings();
         settings.setUsername("Bossman");
         settings.setPassword("Samu");
@@ -123,7 +125,7 @@ public class DownloadExercisesTest {
         List<Exercise> exercises = download.get();
         Path exercisePath = folder.resolve("2013_ohpeJaOhja/viikko1/Viikko1_001.Nimi");
 
-        assertEquals(exercises.size(), 153);
+        assertEquals(exercises.size(), 152); // 8080-fix fixes everything except 152 != 153?
         assertTrue(Files.exists(exercisePath));
 
         FileUtils.deleteDirectory(exercisePath.toFile());
@@ -140,7 +142,7 @@ public class DownloadExercisesTest {
                 core.downloadExercises(folder, 35, observerMock);
         List<Exercise> exercises = download.get();
         Path exercisePath = folder.resolve("2013_ohpeJaOhja/viikko1/Viikko1_001.Nimi");
-        assertEquals(exercises.size(), 153);
+        assertEquals(exercises.size(), 152);
         assertTrue(Files.exists(exercisePath));
         FileUtils.deleteDirectory(exercisePath.toFile());
         assertFalse(Files.exists(exercisePath));
@@ -150,7 +152,6 @@ public class DownloadExercisesTest {
 
     private CoreTestSettings createSettingsAndWiremock() throws URISyntaxException {
         CoreTestSettings settings1 = new CoreTestSettings();
-        String serverAddress = "http://127.0.0.1:8080";
         settings1.setServerAddress(serverAddress);
         settings1.setUsername("test");
         settings1.setPassword("1234");

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/DownloadExercisesTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/DownloadExercisesTest.java
@@ -46,7 +46,6 @@ import org.junit.Test;
 
 import org.mockito.Mockito;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -125,7 +124,7 @@ public class DownloadExercisesTest {
         List<Exercise> exercises = download.get();
         Path exercisePath = folder.resolve("2013_ohpeJaOhja/viikko1/Viikko1_001.Nimi");
 
-        assertEquals(exercises.size(), 152); // 8080-fix fixes everything except 152 != 153?
+        assertEquals(exercises.size(), 152);
         assertTrue(Files.exists(exercisePath));
 
         FileUtils.deleteDirectory(exercisePath.toFile());

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
@@ -33,8 +33,7 @@ public class GetCourseTest {
     *  is the reason. It gives address directly from the .json. Then when .get() of the getCourse - object is called it
     *  makes the request to :8080 port instead of the wiremocks random open port.
     * */
-    @Rule public WireMockRule wireMock = new WireMockRule();
-
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
     private String serverAddress = "http://127.0.0.1:";
 
     private UrlHelper urlHelper;

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
@@ -26,16 +26,6 @@ import java.net.URISyntaxException;
 
 public class GetCourseTest {
 
-    /*
-    *  Adding 0 to constructor makes this work on all ports,
-    *  but the testCallWithCourseName() -test brakes for some reason.
-    *  The reason lies somewhere deep inside this tmc-core.
-    *  I think GetCourse - class's pollServerForCourseUrl() is the reason.
-    *  It gives address directly from the .json.
-    *  Then when .get() of the getCourse - object is called
-    *  it makes the request to :8080 port instead of the wiremocks random open port.
-    * */
-
     @Rule public WireMockRule wireMock = new WireMockRule(0);
     private String serverAddress = "http://127.0.0.1:";
 

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
@@ -27,10 +27,12 @@ import java.net.URISyntaxException;
 
 public class GetCourseTest {
 
-    @Rule public WireMockRule wireMock = new WireMockRule();
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
+
+    private String serverAddress = "http://127.0.0.1:";
 
     private UrlHelper urlHelper;
-    private URI finalUrl = new URI("http://127.0.0.1:8080/courses/19.json");
+    private URI finalUrl;
     private UrlMatchingStrategy mockUrl;
     private TmcCore core;
     private CoreTestSettings settings;
@@ -39,14 +41,16 @@ public class GetCourseTest {
         settings = new CoreTestSettings();
         settings.setCredentials("test", "1234");
         settings.setCurrentCourse(new Course());
-        settings.setServerAddress("http://localhost:8080/");
         settings.setApiVersion("7");
         urlHelper = new UrlHelper(settings);
         mockUrl = urlPathEqualTo("/courses/19.json");
     }
 
     @Before
-    public void setup() {
+    public void setup() throws URISyntaxException {
+        serverAddress += wireMock.port();
+        settings.setServerAddress(serverAddress);
+        finalUrl = new URI(serverAddress + "/courses/19.json");
         core = new TmcCore(settings);
     }
 

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/GetCourseTest.java
@@ -27,7 +27,13 @@ import java.net.URISyntaxException;
 
 public class GetCourseTest {
 
-    @Rule public WireMockRule wireMock = new WireMockRule(0);
+    /*
+    *  Adding 0 to constructor makes this work on all ports, but the testCallWithCourseName() -test brakes
+    *  for some reason. The reason lies somewhere deep inside this tmc-core. I think GetCourse - class's pollServerForCourseUrl()
+    *  is the reason. It gives address directly from the .json. Then when .get() of the getCourse - object is called it
+    *  makes the request to :8080 port instead of the wiremocks random open port.
+    * */
+    @Rule public WireMockRule wireMock = new WireMockRule();
 
     private String serverAddress = "http://127.0.0.1:";
 
@@ -95,6 +101,7 @@ public class GetCourseTest {
 
     @Test
     public void testCallWithCourseName() throws Exception {
+
         wireMock.stubFor(
                 get(urlPathEqualTo("/courses.json"))
                         .willReturn(aResponse().withBody(ExampleJson.allCoursesExample)));
@@ -102,6 +109,7 @@ public class GetCourseTest {
                 get(urlPathEqualTo("/courses/3.json"))
                         .willReturn(
                                 aResponse().withStatus(200).withBody(ExampleJson.courseExample)));
+
 
         ListenableFuture<Course> getCourse = core.getCourseByName("2013_ohpeJaOhja");
         Course course = getCourse.get();

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/ListCoursesTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/ListCoursesTest.java
@@ -39,10 +39,13 @@ public class ListCoursesTest {
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
-    @Rule public WireMockRule wireMock = new WireMockRule();
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
+
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setUp() throws IOException {
+        serverAddress += wireMock.port();
         communicator = Mockito.mock(UrlCommunicator.class);
         tmcApi = new TmcApi(communicator, settings);
 
@@ -77,7 +80,7 @@ public class ListCoursesTest {
         CoreTestSettings localSettings = new CoreTestSettings();
         localSettings.setUsername("username");
         localSettings.setPassword("password");
-        localSettings.setServerAddress("http://localhost:8080");
+        localSettings.setServerAddress(serverAddress);
 
         new ListCourses(localSettings, new TmcApi(localSettings)).call();
     }

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/SendFeedbackTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/SendFeedbackTest.java
@@ -22,17 +22,19 @@ import java.util.TreeMap;
 
 public class SendFeedbackTest {
 
-    private static final String URL = "http://localhost:8080/feedback";
+    private static String URL = "http://localhost:8080/feedback";
 
     private SendFeedback command;
     private CoreTestSettings settings;
 
-    @Rule public WireMockRule wireMock = new WireMockRule();
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setUp() {
         settings = new CoreTestSettings();
-
+        serverAddress += wireMock.port();
+        URL = serverAddress + "/feedback";
         command = new SendFeedback(settings, testCaseMap(), URL);
     }
 
@@ -60,7 +62,7 @@ public class SendFeedbackTest {
                         .willReturn(WireMock.aResponse().withStatus(200)));
 
         Course currentCourse = new Course();
-        currentCourse.setSpywareUrls(Arrays.asList("http://localhost:8080/spyware"));
+        currentCourse.setSpywareUrls(Arrays.asList(serverAddress + "/spyware"));
         settings.setCurrentCourse(currentCourse);
 
         command = new SendFeedback(settings, testCaseMap(), URL);

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/SendFeedbackTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/SendFeedbackTest.java
@@ -16,13 +16,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
 public class SendFeedbackTest {
-
-    private static String URL = "http://localhost:8080/feedback";
 
     private SendFeedback command;
     private CoreTestSettings settings;
@@ -34,8 +32,7 @@ public class SendFeedbackTest {
     public void setUp() {
         settings = new CoreTestSettings();
         serverAddress += wireMock.port();
-        URL = serverAddress + "/feedback";
-        command = new SendFeedback(settings, testCaseMap(), URL);
+        command = new SendFeedback(settings, testCaseMap(), serverAddress + "/feedback");
     }
 
     private Map<String, String> testCaseMap() {
@@ -52,7 +49,8 @@ public class SendFeedbackTest {
     public void testCallSendsFeedbackToServer() throws Exception {
         String expected =
                 "[{\"question_id\":\"4\", \"answer\":\"jee jee!\"},"
-                        + "{\"question_id\":\"13\", \"answer\":\"Oli kiva tehtävä. Opin paljon koodia, "
+                        + "{\"question_id\":\"13\", \"answer\":\""
+                        + "Oli kiva tehtävä. Opin paljon koodia, "
                         + "nyt tunnen osaavani paljon paremmin\"},{\"question_id\":\"88\", "
                         + "\"answer\":\"<(^)\n (___)\n lorem ipsum, sit dolor amet\"}]";
 
@@ -62,10 +60,10 @@ public class SendFeedbackTest {
                         .willReturn(WireMock.aResponse().withStatus(200)));
 
         Course currentCourse = new Course();
-        currentCourse.setSpywareUrls(Arrays.asList(serverAddress + "/spyware"));
+        currentCourse.setSpywareUrls(Collections.singletonList(serverAddress + "/spyware"));
         settings.setCurrentCourse(currentCourse);
 
-        command = new SendFeedback(settings, testCaseMap(), URL);
+        command = new SendFeedback(settings, testCaseMap(), serverAddress + "/feedback");
 
         command.call();
 

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/SendSpywareDiffsTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/SendSpywareDiffsTest.java
@@ -27,7 +27,8 @@ public class SendSpywareDiffsTest {
     private CoreTestSettings settings;
     private byte[] bytes;
 
-    @Rule public WireMockRule wireMock = new WireMockRule();
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setUp() {
@@ -41,6 +42,7 @@ public class SendSpywareDiffsTest {
         this.bytes = new byte[] {0x01, 0x02, 0x03};
 
         this.command = new SendSpywareDiffs(settings, sender, bytes);
+        serverAddress += wireMock.port();
     }
 
     @Test(expected = TmcCoreException.class)
@@ -72,7 +74,7 @@ public class SendSpywareDiffsTest {
                                         .withBody("SPYWARE TULI PERILLE")));
 
         Course currentCourse = new Course();
-        currentCourse.setSpywareUrls(Arrays.asList("http://localhost:8080/spyware"));
+        currentCourse.setSpywareUrls(Arrays.asList(serverAddress + "/spyware"));
         settings.setCurrentCourse(currentCourse);
 
         command = new SendSpywareDiffs(settings, sender, bytes);

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/SubmitTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/SubmitTest.java
@@ -10,7 +10,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 
 import fi.helsinki.cs.tmc.core.CoreTestSettings;
 import fi.helsinki.cs.tmc.core.TmcCore;
@@ -24,6 +28,7 @@ import fi.helsinki.cs.tmc.core.domain.submission.SubmissionResult;
 import fi.helsinki.cs.tmc.core.exceptions.ExpiredException;
 import fi.helsinki.cs.tmc.core.exceptions.TmcCoreException;
 import fi.helsinki.cs.tmc.core.testhelpers.ExampleJson;
+import fi.helsinki.cs.tmc.langs.domain.NoLanguagePluginFoundException;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -31,13 +36,12 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import fi.helsinki.cs.tmc.langs.domain.NoLanguagePluginFoundException;
+
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -45,15 +49,9 @@ import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 public class SubmitTest {
 
-    /**
-     * Here the same problem as in GetCourseTest
-     * */
 
     private Submit submit;
     private ExerciseSubmitter submitterMock;
@@ -61,20 +59,63 @@ public class SubmitTest {
     private String submissionUrl;
     private ProgressObserver observer;
 
-    @Rule public WireMockRule wireMock = new WireMockRule();
+    @Rule public WireMockRule wireMock = new WireMockRule(0);
     private String serverAddress = "http://127.0.0.1:";
 
     private Submit submitWithObserver;
     private SubmissionPoller pollerMock;
     private String path;
 
-    @Before
-    public void setup() throws Exception {
+    private void createSettings() {
         settings = new CoreTestSettings();
         settings.setUsername("Samu");
         settings.setPassword("Bossman");
         settings.setCurrentCourse(new Course());
         settings.setApiVersion("7");
+    }
+
+    private void buildWireMock() throws URISyntaxException {
+        wireMock.stubFor(
+                post(urlPathEqualTo("/exercises/1231/submissions.json"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(200)
+                                        .withBody(
+                                                ExampleJson.failedSubmitResponse.replace(
+                                                        "https://tmc.mooc.fi/staging",
+                                                        serverAddress)
+                                                        .replaceAll(
+                                                                "8080",
+                                                                String.valueOf(wireMock.port())))));
+
+        wireMock.stubFor(
+                get(urlPathEqualTo("/submissions/7777.json"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(200)
+                                        .withBody(
+                                                ExampleJson.failedSubmission
+                                                        .replace(
+                                                                "https://tmc.mooc.fi/staging",
+                                                                serverAddress)
+                                                        .replaceAll(
+                                                                "8080",
+                                                                String.valueOf(wireMock.port())))));
+
+        wireMock.stubFor(
+                get(urlPathEqualTo("/courses/19.json"))
+                        .willReturn(
+                                WireMock.aResponse()
+                                        .withStatus(200)
+                                        .withBody(
+                                                ExampleJson.noDeadlineCourseExample.replace(
+                                                        "https://tmc.mooc.fi/staging",
+                                                        serverAddress))));
+    }
+
+    @Before
+    public void setup() throws Exception {
+        createSettings();
 
         serverAddress += wireMock.port();
 
@@ -176,41 +217,11 @@ public class SubmitTest {
             throws TmcCoreException, IOException, ParseException, ExpiredException,
                     IllegalArgumentException, InterruptedException, URISyntaxException,
                     NoLanguagePluginFoundException {
+
         when(submitterMock.submit(eq(path), eq(observer))).thenReturn("xkcd.com");
         submitWithObserver.call();
         verify(submitterMock).submit(eq(path), eq(observer));
         verify(pollerMock).getSubmissionResult(eq("xkcd.com"), eq(observer));
     }
 
-    private void buildWireMock() throws URISyntaxException {
-        wireMock.stubFor(
-                post(urlPathEqualTo("/exercises/1231/submissions.json"))
-                        .willReturn(
-                                WireMock.aResponse()
-                                        .withStatus(200)
-                                        .withBody(
-                                                ExampleJson.failedSubmitResponse.replace(
-                                                        "https://tmc.mooc.fi/staging",
-                                                        serverAddress))));
-
-        wireMock.stubFor(
-                get(urlPathEqualTo("/submissions/7777.json"))
-                        .willReturn(
-                                WireMock.aResponse()
-                                        .withStatus(200)
-                                        .withBody(
-                                                ExampleJson.failedSubmission.replace(
-                                                        "https://tmc.mooc.fi/staging",
-                                                        serverAddress))));
-
-        wireMock.stubFor(
-                get(urlPathEqualTo("/courses/19.json"))
-                        .willReturn(
-                                WireMock.aResponse()
-                                        .withStatus(200)
-                                        .withBody(
-                                                ExampleJson.noDeadlineCourseExample.replace(
-                                                        "https://tmc.mooc.fi/staging",
-                                                        serverAddress))));
-    }
 }

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/SubmitTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/SubmitTest.java
@@ -51,6 +51,10 @@ import static org.mockito.Mockito.verify;
 
 public class SubmitTest {
 
+    /**
+     * Here the same problem as in GetCourseTest
+     * */
+
     private Submit submit;
     private ExerciseSubmitter submitterMock;
     private CoreTestSettings settings;
@@ -58,6 +62,7 @@ public class SubmitTest {
     private ProgressObserver observer;
 
     @Rule public WireMockRule wireMock = new WireMockRule();
+    private String serverAddress = "http://127.0.0.1:";
 
     private Submit submitWithObserver;
     private SubmissionPoller pollerMock;
@@ -71,6 +76,8 @@ public class SubmitTest {
         settings.setCurrentCourse(new Course());
         settings.setApiVersion("7");
 
+        serverAddress += wireMock.port();
+
         observer = mock(ProgressObserver.class);
 
         submissionUrl = new UrlHelper(settings).withParams("/submissions/1781.json");
@@ -80,7 +87,7 @@ public class SubmitTest {
 
         path = Paths.get("polku", "kurssi", "kansioon", "src").toString();
 
-        when(submitterMock.submit(anyString())).thenReturn("http://127.0.0.1:8080" + submissionUrl);
+        when(submitterMock.submit(anyString())).thenReturn(serverAddress + submissionUrl);
         submit =
                 new Submit(
                         settings, submitterMock, new SubmissionPoller(new TmcApi(settings)), path);
@@ -132,7 +139,7 @@ public class SubmitTest {
     public void submitWithTmcCore() throws Exception {
         buildWireMock();
 
-        CoreTestSettings settings = new CoreTestSettings("test", "1234", "http://localhost:8080");
+        CoreTestSettings settings = new CoreTestSettings("test", "1234", serverAddress);
         TmcApi tmcApi = new TmcApi(settings);
         Course course = tmcApi.getCourseFromString(ExampleJson.noDeadlineCourseExample);
         settings.setCurrentCourse(course);
@@ -184,7 +191,7 @@ public class SubmitTest {
                                         .withBody(
                                                 ExampleJson.failedSubmitResponse.replace(
                                                         "https://tmc.mooc.fi/staging",
-                                                        "http://localhost:8080"))));
+                                                        serverAddress))));
 
         wireMock.stubFor(
                 get(urlPathEqualTo("/submissions/7777.json"))
@@ -194,7 +201,7 @@ public class SubmitTest {
                                         .withBody(
                                                 ExampleJson.failedSubmission.replace(
                                                         "https://tmc.mooc.fi/staging",
-                                                        "http://localhost:8080"))));
+                                                        serverAddress))));
 
         wireMock.stubFor(
                 get(urlPathEqualTo("/courses/19.json"))
@@ -204,6 +211,6 @@ public class SubmitTest {
                                         .withBody(
                                                 ExampleJson.noDeadlineCourseExample.replace(
                                                         "https://tmc.mooc.fi/staging",
-                                                        "http://localhost:8080"))));
+                                                        serverAddress))));
     }
 }

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/VerifyCredentialsTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/VerifyCredentialsTest.java
@@ -29,12 +29,14 @@ public class VerifyCredentialsTest {
     private CoreTestSettings settings;
     private UrlCommunicator comm;
 
-    @Rule public WireMockRule wireMockServer = new WireMockRule();
+    @Rule public WireMockRule wireMockServer = new WireMockRule(0);
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setUp() {
+        serverAddress += wireMockServer.port();
         settings = new CoreTestSettings();
-        settings.setServerAddress("http://127.0.0.1:8080/");
+        settings.setServerAddress(serverAddress);
         comm = new UrlCommunicator(settings);
     }
 

--- a/src/test/java/fi/helsinki/cs/tmc/core/communication/ExerciseDownloaderTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/communication/ExerciseDownloaderTest.java
@@ -42,7 +42,9 @@ import static org.mockito.Matchers.eq;
 
 public class ExerciseDownloaderTest {
 
-    @Rule public WireMockRule wireMockRule = new WireMockRule();
+    @Rule public WireMockRule wireMockRule = new WireMockRule(0);
+
+    private String serverAddress = "http://127.0.0.1:";
 
     private ArrayList<Exercise> exercises;
     private ExerciseDownloader exDl;
@@ -60,6 +62,8 @@ public class ExerciseDownloaderTest {
     public void setup() {
         settings = new CoreTestSettings();
 
+        serverAddress += wireMockRule.port();
+
         exDl = new ExerciseDownloader(new UrlCommunicator(settings), new TmcApi(settings));
         exercises = new ArrayList<>();
 
@@ -68,20 +72,20 @@ public class ExerciseDownloaderTest {
         zipDestination = Paths.get("src", "test", "resources", "__files").toString();
 
         modelSolutionExample = new Exercise();
-        modelSolutionExample.setSolutionDownloadUrl("http://127.0.0.1:8080/model");
+        modelSolutionExample.setSolutionDownloadUrl(serverAddress + "/model");
 
         Exercise e1 = new Exercise();
-        e1.setZipUrl("http://127.0.0.1:8080/ex1.zip");
+        e1.setZipUrl(serverAddress + "/ex1.zip");
         e1.setName("Exercise1");
         exercises.add(e1);
 
         Exercise e2 = new Exercise();
-        e2.setZipUrl("http://127.0.0.1:8080/ex2.zip");
+        e2.setZipUrl(serverAddress + "/ex2.zip");
         e2.setName("Exercise2");
         exercises.add(e2);
 
         Exercise e3 = new Exercise();
-        e3.setZipUrl("http://127.0.0.1:8080/ex3.zip");
+        e3.setZipUrl(serverAddress + "/ex3.zip");
         e3.setName("Exercise3");
         exercises.add(e3);
 

--- a/src/test/java/fi/helsinki/cs/tmc/core/communication/UrlCommunicatorTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/communication/UrlCommunicatorTest.java
@@ -35,7 +35,11 @@ public class UrlCommunicatorTest {
     private CoreTestSettings settings = new CoreTestSettings();
     private UrlCommunicator urlCommunicator;
 
-    @Rule public WireMockRule wireMockRule = new WireMockRule();
+    // NOTE: the 0 here means first open port.
+    @Rule public WireMockRule wireMockRule = new WireMockRule(0);
+
+    // Placeholder for the serverName
+    private String serverAddress = "http://127.0.0.1:";
 
     @Before
     public void setUpWireMock() {
@@ -65,25 +69,26 @@ public class UrlCommunicatorTest {
                         .willReturn(aResponse().withBody("OK").withStatus(200)));
 
         urlCommunicator = new UrlCommunicator(settings);
+        serverAddress += wireMockRule.port();
     }
 
     @Test
     public void okWithValidParams() throws IOException, TmcCoreException {
-        HttpResult result = urlCommunicator.makeGetRequest("http://127.0.0.1:8080", "test:1234");
+        HttpResult result = urlCommunicator.makeGetRequest(serverAddress, "test:1234");
         assertEquals(200, result.getStatusCode());
     }
 
     @Test
     public void badRequestWithoutValidUrl() throws IOException, TmcCoreException {
         HttpResult result =
-                urlCommunicator.makeGetRequest("http://127.0.0.1:8080/vaaraurl", "test:1234");
+                urlCommunicator.makeGetRequest(serverAddress + "/vaaraurl", "test:1234");
         assertEquals(400, result.getStatusCode());
     }
 
     @Test
     public void notFoundWithoutValidParams() throws IOException, TmcCoreException {
         HttpResult result =
-                urlCommunicator.makeGetRequest("http://127.0.0.1:8080/", "ihanvaaraheaderi:1234");
+                urlCommunicator.makeGetRequest(serverAddress, "ihanvaaraheaderi:1234");
         assertEquals(403, result.getStatusCode());
     }
 
@@ -95,7 +100,7 @@ public class UrlCommunicatorTest {
         HttpResult result =
                 urlCommunicator.makePostWithFile(
                         new FileBody(testFile),
-                        "http://127.0.0.1:8080/kivaurl",
+                        serverAddress + "/kivaurl",
                         new HashMap<String, String>());
 
         assertEquals("All tests passed", result.getData());
@@ -111,7 +116,7 @@ public class UrlCommunicatorTest {
         HttpResult result =
                 urlCommunicator.makePostWithFileAndParams(
                         new FileBody(testFile),
-                        "http://127.0.0.1:8080/kivaurl",
+                        serverAddress + "/kivaurl",
                         new HashMap<String, String>(),
                         params);
 
@@ -130,7 +135,7 @@ public class UrlCommunicatorTest {
         Map<String, String> body = new HashMap<>();
         body.put("mark_as_read", "1");
         HttpResult makePutRequest =
-                urlCommunicator.makePutRequest("http://127.0.0.1:8080/putty", Optional.of(body));
+                urlCommunicator.makePutRequest(serverAddress + "/putty", Optional.of(body));
         assertEquals(200, makePutRequest.getStatusCode());
     }
 
@@ -143,7 +148,7 @@ public class UrlCommunicatorTest {
         body.put("mark_as_read", "1");
         HttpResult makePutRequest =
                 urlCommunicator.makePutRequest(
-                        "http://127.0.0.1:8080/putty_with_headers", Optional.of(body));
+                        serverAddress + "/putty_with_headers", Optional.of(body));
         assertEquals(200, makePutRequest.getStatusCode());
     }
 }

--- a/src/test/java/fi/helsinki/cs/tmc/core/spyware/DiffSenderTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/spyware/DiffSenderTest.java
@@ -29,13 +29,13 @@ import java.util.List;
 
 public class DiffSenderTest {
 
-    @Rule public WireMockRule wireMockRule = new WireMockRule();
+    @Rule public WireMockRule wireMockRule = new WireMockRule(0);
+    private String serverAddress = "http://127.0.0.1:";
 
     @Rule public ExpectedException exceptedEx = ExpectedException.none();
 
-    private final String spywareUrl = "http://127.0.0.1:8080/spyware";
+    private String spywareUrl;
     private DiffSender sender;
-    private String originalServerUrl;
     private CoreTestSettings settings;
 
     /**
@@ -47,6 +47,9 @@ public class DiffSenderTest {
         settings.setServerAddress("http://127.0.0.1:8080");
         settings.setUsername("test");
         settings.setPassword("1234");
+
+        serverAddress += wireMockRule.port();
+        spywareUrl = serverAddress + "/spyware";
 
         sender = new DiffSender(settings);
         startWiremock();


### PR DESCRIPTION
This fixes about 95% of the bugs that are related to the 8080-port and all 95% of the tests now use random free port (Tested with the command `python -m SimpleHTTPServer 8080`). The missing 5% are two tests that I have no clue about why those are failing when the port is not 8080.

Check `GetCourseTest` and `SubmitTest` for more information. 
