### PR TITLE
Progress observer improvement

### DIFF
--- a/src/main/java/fi/helsinki/cs/tmc/core/TmcCore.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/TmcCore.java
@@ -24,16 +24,15 @@ import fi.helsinki.cs.tmc.core.holders.TmcLangsHolder;
 import fi.helsinki.cs.tmc.core.holders.TmcSettingsHolder;
 import fi.helsinki.cs.tmc.core.spyware.LoggableEvent;
 import fi.helsinki.cs.tmc.langs.abstraction.ValidationResult;
+import fi.helsinki.cs.tmc.langs.domain.RunResult;
+import fi.helsinki.cs.tmc.langs.util.TaskExecutor;
 
 import com.google.common.annotations.Beta;
 
-import fi.helsinki.cs.tmc.langs.domain.RunResult;
-import fi.helsinki.cs.tmc.langs.util.TaskExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -122,7 +121,7 @@ public class TmcCore {
         return new Submit(observer, exercise);
     }
 
-    public Callable<GetUpdatableExercises.UpdateResult>getExerciseUpdates(
+    public Callable<GetUpdatableExercises.UpdateResult> getExerciseUpdates(
             ProgressObserver observer, Course course) {
         logger.info("Creating new GetUpdatableExercises command");
         return new GetUpdatableExercises(observer, course);

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/AbstractSubmissionCommand.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/AbstractSubmissionCommand.java
@@ -19,7 +19,8 @@ import java.util.Map;
 
 abstract class AbstractSubmissionCommand<T> extends Command<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractSubmissionCommand.class);
+    private static final Logger logger
+            = LoggerFactory.getLogger(AbstractSubmissionCommand.class);
 
     AbstractSubmissionCommand(ProgressObserver observer) {
         super(observer);

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/AbstractSubmissionCommand.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/AbstractSubmissionCommand.java
@@ -39,21 +39,39 @@ abstract class AbstractSubmissionCommand<T> extends Command<T> {
         byte[] zippedProject;
 
         informObserver(0, "Zipping project");
+
         Path tmcRoot = TmcSettingsHolder.get().getTmcProjectDirectory();
         Path projectPath = exercise.getExerciseDirectory(tmcRoot);
+
+        checkInterrupt();
+        logger.info("Submitting project from path {}", projectPath);
+
         try {
             zippedProject = TmcLangsHolder.get().compressProject(projectPath);
         } catch (IOException | NoLanguagePluginFoundException ex) {
+            informObserver(1, "Failed to compress project");
             logger.warn("Failed to compress project", ex);
             throw new TmcCoreException("Failed to compress project", ex);
         }
+
         extraParams.put("error_msg_locale", TmcSettingsHolder.get().getLocale().toString());
+
+        checkInterrupt();
         informObserver(0.5, "Submitting project");
+        logger.info("Submitting project to server");
+
         try {
-            return tmcServerCommunicationTaskFactory
-                    .getSubmittingExerciseTask(exercise, zippedProject, extraParams)
-                    .call();
+            TmcServerCommunicationTaskFactory.SubmissionResponse response
+                    = tmcServerCommunicationTaskFactory
+                            .getSubmittingExerciseTask(exercise, zippedProject, extraParams)
+                            .call();
+
+            informObserver(1, "Submission successfully completed");
+            logger.info("Submission successfully completed");
+
+            return response;
         } catch (Exception ex) {
+            informObserver(1, "Failed to submit exercise");
             logger.warn("Failed to submit exercise", ex);
             throw new TmcCoreException("Failed to submit exercise", ex);
         }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadCompletedExercises.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadCompletedExercises.java
@@ -15,6 +15,7 @@ public class DownloadCompletedExercises extends Command<Void> {
 
     @Override
     public Void call() throws Exception {
+        informObserver(1, "Completed (nothing was done)");
         logger.warn("Received call to unsupported action, doing nothing");
         throw new UnsupportedOperationException("Not support before CORE MILESTONE 2");
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadModelSolution.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadModelSolution.java
@@ -24,7 +24,8 @@ public class DownloadModelSolution extends ExerciseDownloadingCommand<Exercise> 
 
     @VisibleForTesting
     DownloadModelSolution(ProgressObserver observer,
-                          TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory, Exercise exercise) {
+                          TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory,
+                          Exercise exercise) {
         super(observer, tmcServerCommunicationTaskFactory);
         this.exercise = exercise;
     }
@@ -32,7 +33,9 @@ public class DownloadModelSolution extends ExerciseDownloadingCommand<Exercise> 
     @Override
     public Exercise call() throws Exception {
         Progress progress = new Progress(3);
-        Callable<byte[]> downloadingExerciseSolutionZipTask = tmcServerCommunicationTaskFactory.getDownloadingExerciseSolutionZipTask(exercise);
+        Callable<byte[]> downloadingExerciseSolutionZipTask
+                = tmcServerCommunicationTaskFactory
+                    .getDownloadingExerciseSolutionZipTask(exercise);
         byte[] zip = downloadingExerciseSolutionZipTask.call();
         extractProject(zip, exercise, progress);
         return exercise;

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadModelSolution.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadModelSolution.java
@@ -33,10 +33,16 @@ public class DownloadModelSolution extends ExerciseDownloadingCommand<Exercise> 
     @Override
     public Exercise call() throws Exception {
         Progress progress = new Progress(3);
+
+        logger.info("Downloading model solution for exercise {}", exercise);
+
         Callable<byte[]> downloadingExerciseSolutionZipTask
                 = tmcServerCommunicationTaskFactory
                     .getDownloadingExerciseSolutionZipTask(exercise);
         byte[] zip = downloadingExerciseSolutionZipTask.call();
+
+        checkInterrupt();
+
         extractProject(zip, exercise, progress);
         return exercise;
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadOrUpdateExercises.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadOrUpdateExercises.java
@@ -51,6 +51,9 @@ public class DownloadOrUpdateExercises extends ExerciseDownloadingCommand<List<E
     public List<Exercise> call() throws TmcInterruptionException {
         List<Exercise> successfullyDownloaded = new ArrayList<>();
 
+
+        logger.info("Downloading/updating {} exercises", exercises.size());
+
         /*
          * 3 states per exercise,
          * 1) download zip
@@ -89,6 +92,9 @@ public class DownloadOrUpdateExercises extends ExerciseDownloadingCommand<List<E
 
             //TODO: Make into future / callable / something?
         }
+
+        logger.info("Successfully downloaded and extracted {} exercises",
+                successfullyDownloaded.size());
         return successfullyDownloaded;
     }
 

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadOrUpdateExercises.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/DownloadOrUpdateExercises.java
@@ -28,7 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DownloadOrUpdateExercises extends ExerciseDownloadingCommand<List<Exercise>> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DownloadOrUpdateExercises.class);
+    private static final Logger logger
+            = LoggerFactory.getLogger(DownloadOrUpdateExercises.class);
 
     private List<Exercise> exercises;
 
@@ -39,10 +40,10 @@ public class DownloadOrUpdateExercises extends ExerciseDownloadingCommand<List<E
 
     @VisibleForTesting
     DownloadOrUpdateExercises(
-        ProgressObserver observer,
-        List<Exercise> exercises,
-        TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
-        super(observer, tmcServerCommunicationTaskFactory);
+            ProgressObserver observer,
+            List<Exercise> exercises,
+            TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
+            super(observer, tmcServerCommunicationTaskFactory);
         this.exercises = exercises;
     }
 
@@ -81,7 +82,8 @@ public class DownloadOrUpdateExercises extends ExerciseDownloadingCommand<List<E
             }
 
             successfullyDownloaded.add(exercise);
-            informObserver(progress.incrementAndGet(), "Downloaded exercise " + exercise.getName());
+            informObserver(progress.incrementAndGet(),
+                           "Downloaded exercise " + exercise.getName());
 
             //TODO: Update PluginState
 

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/ExerciseDownloadingCommand.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/ExerciseDownloadingCommand.java
@@ -23,7 +23,8 @@ import java.nio.file.Path;
 
 abstract class ExerciseDownloadingCommand<T> extends Command<T> {
 
-    private static final Logger logger = LoggerFactory.getLogger(ExerciseDownloadingCommand.class);
+    private static final Logger logger
+            = LoggerFactory.getLogger(ExerciseDownloadingCommand.class);
 
     public ExerciseDownloadingCommand(ProgressObserver observer) {
         super(observer);
@@ -33,23 +34,32 @@ abstract class ExerciseDownloadingCommand<T> extends Command<T> {
         super(settings, observer);
     }
 
-    public ExerciseDownloadingCommand(ProgressObserver observer, TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
+    public ExerciseDownloadingCommand(
+            ProgressObserver observer,
+            TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
         super(observer, tmcServerCommunicationTaskFactory);
     }
 
-    public ExerciseDownloadingCommand(TmcSettings settings, ProgressObserver observer, TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
+    public ExerciseDownloadingCommand(
+                TmcSettings settings,
+                ProgressObserver observer,
+                TmcServerCommunicationTaskFactory tmcServerCommunicationTaskFactory) {
         super(settings, observer, tmcServerCommunicationTaskFactory);
     }
 
     protected byte[] downloadExercise(Exercise exercise, Progress progress) throws Exception {
         informObserver(progress.incrementAndGet(), "Downloading exercise " + exercise.getName());
 
-        return tmcServerCommunicationTaskFactory.getDownloadingExerciseZipTask(exercise).call();
+        return tmcServerCommunicationTaskFactory
+                .getDownloadingExerciseZipTask(exercise)
+                .call();
     }
 
-    protected void extractSolution(byte[] zip, Exercise exercise, Progress progress) throws
-        TmcInterruptionException, TmcCoreException {
+    protected void extractSolution(byte[] zip, Exercise exercise, Progress progress)
+        throws TmcInterruptionException, TmcCoreException {
         Path exerciseZipTemporaryPath = writeToTmp(zip, exercise, progress);
+        Path target = exercise.getExtractionTarget(
+                TmcSettingsHolder.get().getTmcProjectDirectory());
 
         Path target = exercise.getExtractionTarget(TmcSettingsHolder.get().getTmcProjectDirectory());
 
@@ -57,18 +67,19 @@ abstract class ExerciseDownloadingCommand<T> extends Command<T> {
             TmcLangsHolder.get().extractAndRewriteEveryhing(exerciseZipTemporaryPath, target);
         } catch (Exception ex) {
             logger.warn(
-                "Failed to extract project from "
-                    + exerciseZipTemporaryPath
-                    + " to "
-                    + target,
-                ex);
+                    "Failed to extract project from "
+                        + exerciseZipTemporaryPath
+                        + " to "
+                        + target,
+                    ex);
             throw new ExtractingExericeFailedException(exercise, ex);
         } finally {
             cleanUp(exerciseZipTemporaryPath);
         }
     }
 
-    private Path writeToTmp(byte[] zip, Exercise exercise, Progress progress) throws ExerciseDownloadFailedException, TmcInterruptionException {
+    private Path writeToTmp(byte[] zip, Exercise exercise, Progress progress)
+        throws ExerciseDownloadFailedException, TmcInterruptionException {
         Path exerciseZipTemporaryPath;
         try {
             exerciseZipTemporaryPath = writeToTemp(zip);
@@ -82,21 +93,22 @@ abstract class ExerciseDownloadingCommand<T> extends Command<T> {
         return exerciseZipTemporaryPath;
     }
 
-    protected void extractProject(byte[] zip, Exercise exercise, Progress progress) throws
-        TmcInterruptionException, TmcCoreException{
+    protected void extractProject(byte[] zip, Exercise exercise, Progress progress)
+        throws TmcInterruptionException, TmcCoreException {
         Path exerciseZipTemporaryPath = writeToTmp(zip, exercise, progress);
 
-        Path target = exercise.getExtractionTarget(TmcSettingsHolder.get().getTmcProjectDirectory());
+        Path target = exercise
+                .getExtractionTarget(TmcSettingsHolder.get().getTmcProjectDirectory());
 
         try {
             TmcLangsHolder.get().extractProject(exerciseZipTemporaryPath, target);
         } catch (Exception ex) {
             logger.warn(
-                "Failed to extract project from "
-                    + exerciseZipTemporaryPath
-                    + " to "
-                    + target,
-                ex);
+                    "Failed to extract project from "
+                        + exerciseZipTemporaryPath
+                        + " to "
+                        + target,
+                    ex);
             throw new ExtractingExericeFailedException(exercise, ex);
         } finally {
             cleanUp(exerciseZipTemporaryPath);

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/GetCourseDetails.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/GetCourseDetails.java
@@ -36,11 +36,18 @@ public class GetCourseDetails extends Command<Course> {
 
     @Override
     public Course call() throws TmcCoreException, URISyntaxException {
+        logger.info("Fetching course details");
         informObserver(0, "Refreshing course.");
         try {
-            return tmcServerCommunicationTaskFactory.getFullCourseInfoTask(course).call();
+            Course result = tmcServerCommunicationTaskFactory
+                                .getFullCourseInfoTask(course)
+                                .call();
+            logger.info("Successfully got course details");
+            informObserver(1, "Course refresh completed successfully");
+            return result;
         } catch (Exception ex) {
             logger.warn("Failed to get course details for course " + course.getName(), ex);
+            informObserver(1, "Failed to refresh course");
             throw new TmcCoreException("Failed to get course details", ex);
         }
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/GetUnreadReviews.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/GetUnreadReviews.java
@@ -26,6 +26,7 @@ public class GetUnreadReviews extends Command<Void> {
      */
     @Override
     public Void call() throws TmcCoreException {
+        informObserver(1, "Completed (nothing was done)");
         logger.warn("Received call to unsupported action, doing nothing");
         throw new UnsupportedOperationException("Not supported before CORE MILESTONE 2");
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/GetUpdatableExercises.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/GetUpdatableExercises.java
@@ -63,7 +63,10 @@ public class GetUpdatableExercises extends Command<GetUpdatableExercises.UpdateR
     public UpdateResult call() throws TmcCoreException {
         Course updatedCourse;
         try {
-            updatedCourse = new GetCourseDetails(observer, course, tmcServerCommunicationTaskFactory).call();
+            updatedCourse = new GetCourseDetails(
+                    observer,
+                    course,
+                    tmcServerCommunicationTaskFactory).call();
         } catch (Exception ex) {
             logger.warn("Failed to fetch exercises from server", ex);
             throw new TmcCoreException("Failed to fetch exercises from server", ex);

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/ListCourses.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/ListCourses.java
@@ -33,10 +33,18 @@ public class ListCourses extends Command<List<Course>> {
 
     @Override
     public List<Course> call() throws TmcCoreException {
+        logger.info("Retrieving course list");
+        informObserver(0, "Retrieving course list");
         try {
-            return tmcServerCommunicationTaskFactory.getDownloadingCourseListTask().call();
+            List<Course> result = tmcServerCommunicationTaskFactory
+                                        .getDownloadingCourseListTask()
+                                        .call();
+            informObserver(1, "Successfully fetched course list");
+            logger.debug("Successfully fetched course list");
+            return result;
         } catch (Exception ex) {
             logger.warn("Failed to fetch courses from the server", ex);
+            informObserver(1, "Failed to fetch courses from the server");
             throw new TmcCoreException("Failed to fetch courses from the server", ex);
         }
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/PasteWithComment.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/PasteWithComment.java
@@ -6,6 +6,9 @@ import fi.helsinki.cs.tmc.core.domain.ProgressObserver;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +17,8 @@ import java.util.Map;
  * A {@link Command} for sending a paste to the server with an attached comment.
  */
 public class PasteWithComment extends AbstractSubmissionCommand<URI> {
+
+    private static final Logger logger = LoggerFactory.getLogger(PasteWithComment.class);
 
     private Exercise exercise;
     private String message;
@@ -37,6 +42,8 @@ public class PasteWithComment extends AbstractSubmissionCommand<URI> {
 
     @Override
     public URI call() throws Exception {
+        logger.info("Creating a TMC paste");
+        informObserver(0, "Creating a TMC paste");
 
         Map<String, String> extraParams = new HashMap<>();
         extraParams.put("paste", "1");
@@ -46,6 +53,9 @@ public class PasteWithComment extends AbstractSubmissionCommand<URI> {
 
         TmcServerCommunicationTaskFactory.SubmissionResponse submissionResponse =
                 submitToServer(exercise, extraParams);
+
+        logger.debug("Successfully created TMC paste");
+        informObserver(1, "Successfully created TMC paste");
 
         return submissionResponse.pasteUrl;
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/RequestCodeReview.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/RequestCodeReview.java
@@ -18,6 +18,7 @@ public class RequestCodeReview extends Command<Void> {
 
     @Override
     public Void call() throws Exception {
+        informObserver(1, "Completed (nothing was done)");
         logger.warn("Received call to unsupported action, doing nothing");
         throw new UnsupportedOperationException("Not supported before CORE MILESTONE 3");
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/RunCheckStyle.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/RunCheckStyle.java
@@ -29,10 +29,21 @@ public class RunCheckStyle extends Command<ValidationResult> {
 
     @Override
     public ValidationResult call() throws TmcCoreException {
+        logger.info("Running code style validation for exercise {}", exercise.getName());
+        informObserver(0, "Running code style validation");
+
         Path path = exercise.getExerciseDirectory(TmcSettingsHolder.get().getTmcProjectDirectory());
+        logger.debug("Determined exercise path: {}", path);
+
         try {
-            return TmcLangsHolder.get().runCheckCodeStyle(path, settings.getLocale());
+            logger.debug("Calling TMC langs");
+            ValidationResult result = TmcLangsHolder.get()
+                                            .runCheckCodeStyle(path, settings.getLocale());
+            logger.debug("Received validation result");
+            informObserver(1, "Finished running code style validation");
+            return result;
         } catch (NoLanguagePluginFoundException ex) {
+            informObserver(1, "Failed to run code style validation");
             logger.warn("Failed to run code style validations on target path", ex);
             throw new TmcCoreException("Unable to run code style validations on target path", ex);
         }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/RunTests.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/RunTests.java
@@ -29,10 +29,20 @@ public class RunTests extends Command<RunResult> {
 
     @Override
     public RunResult call() throws TmcCoreException {
+        logger.info("Running tests for exercise {}", exercise.getName());
+        informObserver(0, "Running tests");
+
         Path path = exercise.getExerciseDirectory(TmcSettingsHolder.get().getTmcProjectDirectory());
+        logger.debug("Determined project path as {}", path);
+
         try {
-            return TmcLangsHolder.get().runTests(path);
+            logger.debug("Calling TMC Langs");
+            RunResult result = TmcLangsHolder.get().runTests(path);
+            logger.debug("Successfully ran tests");
+            informObserver(1, "Finished running tests");
+            return result;
         } catch (NoLanguagePluginFoundException ex) {
+            informObserver(1, "Failed to run tests");
             logger.warn("Failed to run tests for project", ex);
             throw new TmcCoreException("Failed to run tests for project", ex);
         }

--- a/src/main/java/fi/helsinki/cs/tmc/core/commands/SendSpywareEvents.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/commands/SendSpywareEvents.java
@@ -33,6 +33,8 @@ public class SendSpywareEvents extends Command<Void> {
     // TODO: test
     @Override
     public Void call() throws Exception {
+        logger.info("Sending usage data");
+        informObserver(0, "Sending usage data");
         if (currentCourse.getSpywareUrls() == null || currentCourse.getSpywareUrls().isEmpty()) {
             logger.info("Failed to send events: " + "Current course has no spyware servers set");
             throw new NoSpywareServerException("Current course has no spyware servers set");
@@ -42,6 +44,9 @@ public class SendSpywareEvents extends Command<Void> {
         URI spywareServerUri = currentCourse.getSpywareUrls().get(serverId);
 
         new TmcServerCommunicationTaskFactory().getSendEventLogJob(spywareServerUri, events).call();
+
+        logger.debug("Usage data sent");
+        informObserver(1, "Done sending usage data");
 
         return null; // Can't instantiate Void
     }

--- a/src/main/java/fi/helsinki/cs/tmc/core/domain/Exercise.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/domain/Exercise.java
@@ -351,11 +351,15 @@ public class Exercise implements Serializable {
      * The exercises are same if the name and the course are the same.
      */
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
 
-        Exercise exercise = (Exercise) o;
+        Exercise exercise = (Exercise) other;
 
         if (!name.equals(exercise.name)) {
             return false;

--- a/src/main/java/fi/helsinki/cs/tmc/core/utilities/SingletonTask.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/utilities/SingletonTask.java
@@ -6,8 +6,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A task that can be started repeatedly, but ensures only one instance is running at a time.

--- a/src/test/java/fi/helsinki/cs/tmc/core/commands/GetUpdatableExercisesTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/commands/GetUpdatableExercisesTest.java
@@ -102,7 +102,8 @@ public class GetUpdatableExercisesTest {
         GetUpdatableExercises.UpdateResult updateResults = command.call();
 
         assertThat(updateResults.getNewExercises()).containsExactly(newRefreshedExercise);
-        assertThat(updateResults.getUpdatedExercises()).containsExactly(updateableRefreshedExercise);
+        assertThat(updateResults.getUpdatedExercises())
+                .containsExactly(updateableRefreshedExercise);
     }
 
     @Test


### PR DESCRIPTION
Much more logging for commands:
- `INFO` level logging when entering a `Command`
- `DEBUG` level logging inside `Command`s (with few exception)

**Actually uses progress observers**: Observer is informed on start and end in all major paths, and intermediately when sensible.
