### PR TITLE
Fix parsing of validation case errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>fi.helsinki.cs.tmc</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>tmc-core</name>
     <url>http://testmycode.net</url>

--- a/src/main/java/fi/helsinki/cs/tmc/core/communication/serialization/SubmissionResultParser.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/communication/serialization/SubmissionResultParser.java
@@ -5,7 +5,6 @@ import fi.helsinki.cs.tmc.stylerunner.validation.CheckstyleResult;
 import fi.helsinki.cs.tmc.testrunner.CaughtException;
 import fi.helsinki.cs.tmc.testrunner.StackTraceSerializer;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
@@ -21,6 +20,7 @@ import com.google.gson.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -49,6 +49,11 @@ public class SubmissionResultParser {
                                     StackTraceElement.class, new StackTraceSerializer())
                             .registerTypeAdapter(
                                     ImmutableList.class, new ImmutableListJsonDeserializer())
+                            .registerTypeAdapter(
+                                    /* Needed because ValidationResultImpl stores filenames in
+                                     * Map<File, List<ValidationError>, but Gson doesn't know
+                                     * how to deserialize a string into a File */
+                                    File.class, new FileDeserializer())
                             .create();
 
             SubmissionResult result = gson.fromJson(json, SubmissionResult.class);
@@ -91,7 +96,17 @@ public class SubmissionResultParser {
         }
     }
 
-    private class ImmutableListJsonDeserializer implements JsonDeserializer<ImmutableList<?>> {
+    private static class FileDeserializer implements JsonDeserializer<File> {
+        @Override
+        public File deserialize(
+                JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext)
+                throws JsonParseException {
+            String filePath = jsonElement.getAsString();
+            return new File(filePath);
+        }
+    }
+
+    private static class ImmutableListJsonDeserializer implements JsonDeserializer<ImmutableList<?>> {
         @Override
         public ImmutableList<?> deserialize(
                 JsonElement json, Type type, JsonDeserializationContext context)

--- a/src/main/java/fi/helsinki/cs/tmc/core/communication/serialization/SubmissionResultParser.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/communication/serialization/SubmissionResultParser.java
@@ -104,7 +104,8 @@ public class SubmissionResultParser {
         }
     }
 
-    private static class ValidationErrorInstanceCreator implements InstanceCreator<ValidationError> {
+    private static class ValidationErrorInstanceCreator
+            implements InstanceCreator<ValidationError> {
         @Override
         public ValidationError createInstance(Type type) {
             return new ValidationErrorImpl();
@@ -114,14 +115,15 @@ public class SubmissionResultParser {
     private static class FileDeserializer implements JsonDeserializer<File> {
         @Override
         public File deserialize(
-                JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext)
+                JsonElement jsonElement, Type type, JsonDeserializationContext context)
                 throws JsonParseException {
             String filePath = jsonElement.getAsString();
             return new File(filePath);
         }
     }
 
-    private static class ImmutableListJsonDeserializer implements JsonDeserializer<ImmutableList<?>> {
+    private static class ImmutableListJsonDeserializer
+            implements JsonDeserializer<ImmutableList<?>> {
         @Override
         public ImmutableList<?> deserialize(
                 JsonElement json, Type type, JsonDeserializationContext context)

--- a/src/main/java/fi/helsinki/cs/tmc/core/domain/submission/SubmissionResult.java
+++ b/src/main/java/fi/helsinki/cs/tmc/core/domain/submission/SubmissionResult.java
@@ -75,8 +75,6 @@ public class SubmissionResult {
     @SerializedName("solution_url")
     private String solutionUrl;
 
-    private ValidationResultImpl validations;
-
     private String valgrind;
 
     private boolean reviewed;
@@ -103,14 +101,6 @@ public class SubmissionResult {
 
     public void setError(String error) {
         this.error = error;
-    }
-
-    public ValidationResultImpl getValidations() {
-        return validations;
-    }
-
-    public void setValidations(ValidationResultImpl validations) {
-        this.validations = validations;
     }
 
     public List<TestResult> getTestCases() {
@@ -322,8 +312,6 @@ public class SubmissionResult {
                 + feedbackAnswerUrl
                 + ", solutionUrl="
                 + solutionUrl
-                + ", validations="
-                + validations
                 + ", \n valgrind="
                 + valgrind
                 + ", reviewed="

--- a/src/test/java/fi/helsinki/cs/tmc/core/communication/http/serialization/SubmissionResultParserTest.java
+++ b/src/test/java/fi/helsinki/cs/tmc/core/communication/http/serialization/SubmissionResultParserTest.java
@@ -5,23 +5,21 @@ import static com.google.common.truth.Truth.assertThat;
 import fi.helsinki.cs.tmc.core.communication.serialization.SubmissionResultParser;
 import fi.helsinki.cs.tmc.core.domain.submission.SubmissionResult;
 import fi.helsinki.cs.tmc.core.utils.TestUtils;
+import fi.helsinki.cs.tmc.langs.abstraction.Strategy;
+import fi.helsinki.cs.tmc.langs.abstraction.ValidationError;
+import fi.helsinki.cs.tmc.langs.abstraction.ValidationResult;
 import fi.helsinki.cs.tmc.langs.domain.TestResult;
-import fi.helsinki.cs.tmc.testrunner.TestCase;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.net.URI;
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class SubmissionResultParserTest {
-
 
     private SubmissionResultParser parser;
 
@@ -39,7 +37,7 @@ public class SubmissionResultParserTest {
         TestResult test = tests.get(0);
         assertThat(test.getException()).isInstanceOf(ImmutableList.class);
         assertThat(test.getException().size()).isEqualTo(27);
-        for (String str : test.getException()){
+        for (String str : test.getException()) {
             assertThat(str).isInstanceOf(String.class);
         }
     }
@@ -54,8 +52,30 @@ public class SubmissionResultParserTest {
         TestResult test = tests.get(0);
         assertThat(test.getDetailedMessage()).isInstanceOf(ImmutableList.class);
         assertThat(test.getDetailedMessage().size()).isEqualTo(26);
-        for (String str : test.getDetailedMessage()){
+        for (String str : test.getDetailedMessage()) {
             assertThat(str).isInstanceOf(String.class);
+        }
+    }
+
+    @Test
+    public void parsesTestResultsWithFailedCheckstyle() throws IOException {
+        String json = TestUtils.readJsonFile(this.getClass(), "checkstyleFailed.json");
+        SubmissionResult submissionResult = parser.parseFromJson(json);
+        assertThat(submissionResult).isNotNull();
+
+        ValidationResult result = submissionResult.getValidationResult();
+        assertThat(result.getStrategy()).isEqualTo(Strategy.FAIL);
+
+        Map<File, List<ValidationError>> filesErrors = result.getValidationErrors();
+        assertThat(filesErrors).hasSize(1);
+
+        List<ValidationError> errors = filesErrors.get(new File("error/errorMessages.java"));
+        assertThat(errors).hasSize(73);
+
+        for (ValidationError error : errors) {
+            assertThat(error).isNotNull();
+            assertThat(error.getMessage()).isNotNull();
+            assertThat(error.getSourceName()).isNotNull();
         }
     }
 }

--- a/src/test/resources/json/checkstyleFailed.json
+++ b/src/test/resources/json/checkstyleFailed.json
@@ -205,7 +205,7 @@
                 "strategy": "FAIL",
                 "validationErrors":
                         {
-                            "eRror/errorMessages.java":
+                            "error/errorMessages.java":
                                     [
                                         {
                                             "column": 0,


### PR DESCRIPTION
Currently, responses with validation error information cause an exception in [`SubmissionResultParser`](https://github.com/testmycode/tmc-core/blob/784fe8d8e05a62e8e1f74d075181a5e7b474c7a9/src/main/java/fi/helsinki/cs/tmc/core/communication/serialization/SubmissionResultParser.java#L54) during deserialization (see #109). This happens because [`ValidationResultImpl`](https://github.com/testmycode/tmc-core/blob/784fe8d8e05a62e8e1f74d075181a5e7b474c7a9/src/main/java/fi/helsinki/cs/tmc/core/domain/submission/ValidationResultImpl.java#L14) stores them in a `Map<File, List<ValidationError>>`, but the Gson JSON parser cannot resolve JSON strings into `File` instances. This is fixed by 3809cf8.

Fixing this bug reveals another one: the validation errors cannot be deserialized into `ValidationError` instances because `ValidationError` is an abstract class. This is fixed by 7a94b20.